### PR TITLE
Revamp delete credit card bill feature

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -710,7 +710,8 @@ Take note that there is a maximum of *30* character limit.
 | `CARD_LIMIT` should contain only digits and up to *2* decimal places and a maximum of *9* digits.
 
 | `CASHBACK_RATE`
-| Indicates the cashback returns rate of the credit card in percentage.
+| Indicates the cashback returns rate of the credit card in percentage. Cashback will be deposited
+back into savings account upon adding of card bill.
 
 (e.g. 20 for 20%)
 
@@ -753,14 +754,6 @@ Take note that there is a maximum of *50* character limit.
 | `TRANSACTION_NUMBER`
 | Indicates the transaction number in the list when displayed. It is used for editing or deleting expenditures.
 | `TRANSACTION_NUMBER` should contain positive numbers only up to a maximum of *9* digits.
-
-| `BILL_EXPENDITURE_NUMBER`
-| Indicates the credit card bill transaction number in your savings account.
-| `BILL_EXPENDITURE_NUMBER` should contain positive numbers only up to a maximum of *9* digits.
-
-| `BILL_DEPOSIT_NUMBER`
-| Indicates the credit card bill rebate transaction number in your savings account.
-| `BILL_DEPOSIT_NUMBER` should contain positive numbers only up to a maximum of *9* digits.
 
 |======
 
@@ -936,32 +929,20 @@ can delete your credit card bill, which will delete the bill expenditure and reb
 
 *Command Syntax*
 
-`/delete /cardbill /card CARD_NAME /date YEARMONTH /bank ACCOUNT_NAME /expno BILL_EXPENDITURE_NUMBER /depno
-BILL_DEPOSIT_NUMBER`
-
-[TIP]
-====
-To find out the expenditure and deposit number, use the /list or /find function to find the expenditure number in
-your savings account.
-====
+`/delete /cardbill /card CARD_NAME /date YEARMONTH /bank ACCOUNT_NAME /expno`
 
 [WARNING]
 ====
 Do not use the `/delete /bankexpenditure` or `/delete /deposit` command to remove your credit card bill. By doing so,
 you will be unable to reverse your credit card bill and hence unable to add more credit card expenditures to
 previously paid months.
-
-If you specify an incorrect `/expno`, but if the bank transaction amount matches the total card expenditures from
-`/date`, the incorrect bank expenditure will be deleted.
-
-If you specify an incorrect `/depno`, it will be deleted immediately if `/expno` leads to a deletion.
 ====
 
 *Example*
 
-* `/delete /cardbill /card POBB Tomorrow Card /date 10/2019 /bank JunBank Savings Account /expno 1 /depno 2`
+* `/delete /cardbill /card POBB Tomorrow Card /date 10/2019 /bank JunBank Savings Account`
 
-Deletes credit card bill expenditure `1` and rebate deposit `2` from `JunBank Savings Account`. All credit card
+Deletes credit card bill expenditure and rebate deposit from `JunBank Savings Account`. All credit card
 expenditures from `10/2019` will be marked as unpaid from `POBB Tomorrow Card`.
 
 // tag::goals[]
@@ -1456,6 +1437,11 @@ Take note that there is a maximum of *30* character limit.
 
 `/list /recurbankexp /from ACCOUNT_NAME`
 
+[NOTE]
+====
+Remaining Limit shown in `/list /card` is the limit left for the current month.
+====
+
 [TIP]
 ====
 When `/num` is not specified, it is defaulted to 30 most recent records.
@@ -1795,8 +1781,8 @@ AMOUNT] [/date DATE]`
 
 | *Deleting credit card bill*
 | Delete a credit card bill expenditure and rebate deposit from savings account.
-| `/delete /cardbill /card CARD_NAME /date YEARMONTH /bank ACCOUNT_NAME /expno 1 /depno 2`
-| `/delete /cardbill /card POBB Tomorrow Card /date 10/2019 /bank JunBank Savings Account /expno 1 /depno 2`
+| `/delete /cardbill /card CARD_NAME /date YEARMONTH /bank ACCOUNT_NAME`
+| `/delete /cardbill /card POBB Tomorrow Card /date 10/2019 /bank JunBank Savings Account`
 
 |======
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -896,7 +896,7 @@ To find out which expenditure to delete, use the `/list` or `/find` function to 
 Deletes an expenditure from `POBB Tomorrow Card` with transaction number `1`.
 
 
-===== Adding monthly credit card bill to savings account /add /cardbill
+===== Adding monthly credit card bill to savings account `/add /cardbill`
 
 Charge your credit card monthly bill to your savings account! This will add a credit card bill expenditure and also
 deposit the monthly rebate to your savings account.
@@ -922,7 +922,7 @@ Tomorrow Card` in the month and year of `10/2019`.
 
 Rebates for the month will also be deposited back to `JunBank Savings Account`.
 
-===== Deleting credit card bill from savings account /delete /cardbill
+===== Deleting credit card bill from savings account `/delete /cardbill`
 
 Made a mistake in charging of credit card bill or decided to add more card transaction for an already paid month? You
 can delete your credit card bill, which will delete the bill expenditure and rebate deposit from your savings account!

--- a/src/main/java/owlmoney/logic/command/cardbill/AddCardBillCommand.java
+++ b/src/main/java/owlmoney/logic/command/cardbill/AddCardBillCommand.java
@@ -26,7 +26,6 @@ public class AddCardBillCommand extends Command {
     private final String bank;
     private final String type;
     private final String expDescription;
-    private final String category;
     private static final int PERCENTAGE_TO_DECIMAL = 100;
 
     /**
@@ -43,7 +42,6 @@ public class AddCardBillCommand extends Command {
         this.bank = bank;
         this.type = "bank";
         this.expDescription = "Payment for Credit Card Bill - " + card + " " + date;
-        this.category = "Credit Card";
     }
 
     private Date getCurrentDate() {

--- a/src/main/java/owlmoney/logic/command/cardbill/AddCardBillCommand.java
+++ b/src/main/java/owlmoney/logic/command/cardbill/AddCardBillCommand.java
@@ -5,6 +5,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.YearMonth;
 import java.util.Date;
+import java.util.UUID;
 
 import owlmoney.logic.command.Command;
 import owlmoney.model.bank.exception.BankException;
@@ -79,21 +80,22 @@ public class AddCardBillCommand extends Command {
      * @param profile Profile of the user.
      * @param ui      Ui of OwlMoney.
      * @return        False so OwlMoney will not terminate yet.
-     * @throws CardException        If credit card does not exist.
+     * @throws CardException        If credit card does not exist, or error in paying of card bill.
      * @throws BankException        If bank account does not exist.
      * @throws TransactionException If invalid transaction when deleting.
      */
     public boolean execute(Profile profile, Ui ui) throws CardException, BankException, TransactionException {
         profile.checkCardExists(card);
+        UUID cardId = profile.getCardId(card);
         String depDescription = "Rebate for Credit Card (" + profile.getCardRebateAmount(card) + "%) - "
                 + card + " " + cardDate;
         double billAmount = profile.getCardUnpaidBillAmount(card, cardDate);
         double rebateAmount = (profile.getCardRebateAmount(card) / PERCENTAGE_TO_DECIMAL) * billAmount;
         checkBillAmountZero(billAmount, card, cardDate);
         Expenditure newExpenditure =
-                new Expenditure(this.expDescription, billAmount, this.expDate, this.category);
-        Deposit newDeposit = new Deposit(depDescription, rebateAmount, this.expDate, this.category);
-        profile.payCardBill(card, bank, newExpenditure, newDeposit, cardDate, ui, type);
+                new Expenditure(this.expDescription, billAmount, this.expDate, cardId, this.cardDate);
+        Deposit newDeposit = new Deposit(depDescription, rebateAmount, this.expDate, cardId, this.cardDate);
+        profile.addCardBill(card, bank, newExpenditure, newDeposit, cardDate, ui, type);
         return this.isExit;
     }
 }

--- a/src/main/java/owlmoney/logic/command/cardbill/DeleteCardBillCommand.java
+++ b/src/main/java/owlmoney/logic/command/cardbill/DeleteCardBillCommand.java
@@ -17,8 +17,6 @@ public class DeleteCardBillCommand extends Command {
     private final YearMonth cardDate;
     private final String bank;
     private final String type;
-    private final int expno;
-    private final int depno;
 
     /**
      * Creates an instance of DeleteCardBillCommand.
@@ -26,51 +24,12 @@ public class DeleteCardBillCommand extends Command {
      * @param card  Credit card name of bill to be paid.
      * @param date  Month and year of bill to be paid.
      * @param bank  Bank account name to charge the credit card bill to.
-     * @param expno Transaction number of the credit card bill expenditure to be deleted.
-     * @param depno Transaction number of the credit card bill deposit to be deleted.
      */
-    public DeleteCardBillCommand(String card, YearMonth date, String bank, int expno, int depno) {
+    public DeleteCardBillCommand(String card, YearMonth date, String bank) {
         this.card = card;
         this.cardDate = date;
         this.bank = bank;
-        this.expno = expno;
-        this.depno = depno;
         this.type = "bank";
-
-    }
-
-    /**
-     * Throws an exception if the credit card bill amount for the specified YearMonth date is zero.
-     *
-     * @param amount    The credit card bill amount.
-     * @param card      The credit card name where is bill is from.
-     * @param cardDate  The credit card YearMonth date of the bill.
-     * @throws CardException    If the credit card bill amount for the specified YearMonth date is zero.
-     */
-    private void checkBillAmountZero(double amount, String card, YearMonth cardDate) throws CardException {
-        if (amount == 0) {
-            throw new CardException("You have no paid expenditures for " + card + " for the month of "
-                    + cardDate + "!");
-        }
-    }
-
-    /**
-     * Throws an exception if the entered bill amount does not match with the actual bill amount in the bank.
-     *
-     * @param profile   Profile of the user.
-     * @param bank      The bank account of the bill amount to be checked.
-     * @param amount    The bill amount from the credit card to be checked.
-     * @param expno     The transaction number of the bank expenditure to be checked.
-     * @throws CardException        If card does not exist.
-     * @throws BankException        If bank account does not exist.
-     * @throws TransactionException If transaction is not an expenditure.
-     */
-    private void checkBillAmountMatch(Profile profile, String bank, double amount, int expno)
-            throws CardException, BankException, TransactionException {
-        double amountInBank = profile.getBankExpAmountById(bank, expno);
-        if (amountInBank != amount) {
-            throw new CardException("Expenditure #" + expno + " amount does not match amount in card!");
-        }
     }
 
     /**
@@ -85,13 +44,7 @@ public class DeleteCardBillCommand extends Command {
      * @throws TransactionException If invalid transaction when deleting.
      */
     public boolean execute(Profile profile, Ui ui) throws CardException, BankException, TransactionException {
-        profile.checkCardExists(card);
-        double billAmountInCard = profile.getCardPaidBillAmount(card, cardDate);
-        checkBillAmountZero(billAmountInCard, card, cardDate);
-        checkBillAmountMatch(profile, bank, billAmountInCard, expno);
-        profile.profileDeleteDeposit(depno, bank, ui);
-        profile.profileDeleteExpenditure(expno, bank, ui, type);
-        profile.unpayCardBill(card, cardDate, ui, type);
+        profile.deleteCardBill(card, cardDate, bank, ui, type);
         return this.isExit;
     }
 }

--- a/src/main/java/owlmoney/logic/parser/cardbill/ParseAddCardBill.java
+++ b/src/main/java/owlmoney/logic/parser/cardbill/ParseAddCardBill.java
@@ -12,7 +12,6 @@ import owlmoney.logic.parser.exception.ParserException;
  */
 public class ParseAddCardBill extends ParseCardBill {
     private YearMonth yearMonth;
-    private static final String ADD = "/add";
 
     /**
      * Creates an instance of ParseAddCardBill.

--- a/src/main/java/owlmoney/logic/parser/cardbill/ParseAddCardBill.java
+++ b/src/main/java/owlmoney/logic/parser/cardbill/ParseAddCardBill.java
@@ -22,8 +22,6 @@ public class ParseAddCardBill extends ParseCardBill {
      */
     public ParseAddCardBill(String data) throws ParserException {
         super(data);
-        checkRedundantParameter(EXPNO, ADD);
-        checkRedundantParameter(DEPNO, ADD);
         checkFirstParameter();
     }
 
@@ -39,8 +37,7 @@ public class ParseAddCardBill extends ParseCardBill {
         while (cardBillIterator.hasNext()) {
             String key = cardBillIterator.next();
             String value = cardBillParameters.get(key);
-            if ((CARD.equals(key) || BANK.equals(key) || DATE.equals(key))
-                    && (value.isBlank() || value.isEmpty())) {
+            if (value.isBlank() || value.isEmpty()) {
                 throw new ParserException(key + " cannot be empty when adding making a card bill payment!");
             }
             if (CARD.equals(key)) {

--- a/src/main/java/owlmoney/logic/parser/cardbill/ParseCardBill.java
+++ b/src/main/java/owlmoney/logic/parser/cardbill/ParseCardBill.java
@@ -21,14 +21,12 @@ public abstract class ParseCardBill {
     private ParseRawData parseRawData = new ParseRawData();
     private String rawData;
     private static final String[] CARDBILL_KEYWORD = new String[] {
-        "/card", "/date", "/bank", "/expno", "/depno"
+        "/card", "/date", "/bank"
     };
     private static final List<String> CARDBILL_KEYWORD_LISTS = Arrays.asList(CARDBILL_KEYWORD);
     static final String CARD = "/card";
     static final String BANK = "/bank";
     static final String DATE = "/date";
-    static final String EXPNO = "/expno";
-    static final String DEPNO = "/depno";
     static final String FIRST_DAY = "01/";
 
     /**
@@ -52,10 +50,6 @@ public abstract class ParseCardBill {
                 parseRawData.extractParameter(rawData, BANK, CARDBILL_KEYWORD));
         cardBillParameters.put(DATE,
                 parseRawData.extractParameter(rawData, DATE, CARDBILL_KEYWORD));
-        cardBillParameters.put(EXPNO,
-                parseRawData.extractParameter(rawData, EXPNO, CARDBILL_KEYWORD));
-        cardBillParameters.put(DEPNO,
-                parseRawData.extractParameter(rawData, DEPNO, CARDBILL_KEYWORD));
     }
 
     /**
@@ -108,32 +102,6 @@ public abstract class ParseCardBill {
 
         }
         throw new ParserException("Incorrect date format." + " Date format is mm/yyyy in year range of 1900-2099");
-    }
-
-    /**
-     * Checks the user input for any redundant parameters.
-     *
-     * @param parameter Redundant parameter to check for,
-     * @param command   Command the user performed.
-     * @throws ParserException If a redundant parameter is detected.
-     */
-    void checkRedundantParameter(String parameter, String command) throws ParserException {
-        if (rawData.contains(parameter)) {
-            throw new ParserException(command + " /cardbill should not contain " + parameter);
-        }
-    }
-
-    /**
-     * Checks if the transaction number entered by the user is an integer.
-     *
-     * @param variable User command keyword (e.g. /expno).
-     * @param valueString String to be converted to integer.
-     * @throws ParserException If the string is not an integer.
-     */
-    void checkInt(String variable, String valueString) throws ParserException {
-        if (!RegexUtil.regexCheckListNumber(valueString)) {
-            throw new ParserException(variable + " can only be a positive number with at most 9 digits");
-        }
     }
 
     /**

--- a/src/main/java/owlmoney/logic/parser/cardbill/ParseDeleteCardBill.java
+++ b/src/main/java/owlmoney/logic/parser/cardbill/ParseDeleteCardBill.java
@@ -48,12 +48,6 @@ public class ParseDeleteCardBill extends ParseCardBill {
             if (DATE.equals(key)) {
                 yearMonth = checkDate(value);
             }
-            if (EXPNO.equals(key)) {
-                checkInt(EXPNO, value);
-            }
-            if (DEPNO.equals(key)) {
-                checkInt(DEPNO, value);
-            }
         }
     }
 
@@ -66,8 +60,7 @@ public class ParseDeleteCardBill extends ParseCardBill {
     public Command getCommand() {
         DeleteCardBillCommand newDeleteCardBillCommand =
                 new DeleteCardBillCommand(cardBillParameters.get(CARD), yearMonth,
-                        cardBillParameters.get(BANK), Integer.parseInt(cardBillParameters.get(EXPNO)),
-                        Integer.parseInt(cardBillParameters.get(DEPNO)));
+                        cardBillParameters.get(BANK));
         return newDeleteCardBillCommand;
     }
 }

--- a/src/main/java/owlmoney/model/bank/Bank.java
+++ b/src/main/java/owlmoney/model/bank/Bank.java
@@ -4,7 +4,9 @@ import java.io.IOException;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
+import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.UUID;
 
 import owlmoney.model.bank.exception.BankException;
 import owlmoney.model.bond.Bond;
@@ -498,6 +500,41 @@ public abstract class Bank {
      * @throws BankException If used on savings account.
      */
     boolean investmentIsBondListFull() throws BankException {
+        throw new BankException("This account does not support this feature");
+    }
+
+    /**
+     * Gets if transaction list contains the specified expenditure and deposit.
+     *
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return True if transaction list contains the specified expenditure and deposit.
+     */
+    public boolean isTransactionCardBillExist(UUID cardId, YearMonth billDate) throws BankException {
+        throw new BankException("This account does not support this feature");
+    }
+
+    /**
+     * Gets the index of the expenditure object that is a card bill expenditure
+     * with specified card id and bill date.
+     *
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the expenditure object if found. If not found, return -1.
+     */
+    public int getCardBillExpenditureId(UUID cardId, YearMonth billDate) throws BankException {
+        throw new BankException("This account does not support this feature");
+    }
+
+    /**
+     * Gets the index of the deposit object that is a card bill expenditure
+     * with specified card id and bill date.
+     *
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the deposit object if found. If not found, return -1.
+     */
+    public int getCardBillDepositId(UUID cardId, YearMonth billDate) throws BankException {
         throw new BankException("This account does not support this feature");
     }
 }

--- a/src/main/java/owlmoney/model/bank/BankList.java
+++ b/src/main/java/owlmoney/model/bank/BankList.java
@@ -1154,8 +1154,8 @@ public class BankList {
      */
     public int bankListGetCardBillExpenditureId(String bankName, UUID cardId, YearMonth billDate)
             throws BankException {
-        for(int i = 0; i < bankLists.size(); i++) {
-            if(bankLists.get(i).getAccountName().equals(bankName)) {
+        for (int i = 0; i < bankLists.size(); i++) {
+            if (bankLists.get(i).getAccountName().equals(bankName)) {
                 return bankLists.get(i).getCardBillExpenditureId(cardId, billDate);
             }
         }
@@ -1174,8 +1174,8 @@ public class BankList {
      */
     public int bankListGetCardBillDepositId(String bankName, UUID cardId, YearMonth billDate)
             throws BankException {
-        for(int i = 0; i < bankLists.size(); i++) {
-            if(bankLists.get(i).getAccountName().equals(bankName)) {
+        for (int i = 0; i < bankLists.size(); i++) {
+            if (bankLists.get(i).getAccountName().equals(bankName)) {
                 return bankLists.get(i).getCardBillDepositId(cardId, billDate);
             }
         }

--- a/src/main/java/owlmoney/model/bank/BankList.java
+++ b/src/main/java/owlmoney/model/bank/BankList.java
@@ -5,7 +5,9 @@ import java.math.RoundingMode;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.DecimalFormat;
+import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.UUID;
 
 import owlmoney.model.bank.exception.BankException;
 import owlmoney.model.bond.Bond;
@@ -1138,5 +1140,45 @@ public class BankList {
             }
         }
         throw new BankException("Bank with the following name does not exist: " + bank);
+    }
+
+    /**
+     * Gets the index of the transaction object in specific bank that is a card bill expenditure
+     * with specified card id and bill date.
+     *
+     * @param bankName  The name of the bank to search for transaction id.
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the expenditure transaction object if found. If not found, return -1.
+     * @throws BankException If bank account does not support this feature.
+     */
+    public int bankListGetCardBillExpenditureId(String bankName, UUID cardId, YearMonth billDate)
+            throws BankException {
+        for(int i = 0; i < bankLists.size(); i++) {
+            if(bankLists.get(i).getAccountName().equals(bankName)) {
+                return bankLists.get(i).getCardBillExpenditureId(cardId, billDate);
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Gets the index of the transaction object in specific bank that is a card bill deposit
+     * with specified card id and bill date.
+     *
+     * @param bankName  The name of the bank to search for transaction id.
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the deposit transaction object if found. If not found, return -1.
+     * @throws BankException If bank account does not support this feature.
+     */
+    public int bankListGetCardBillDepositId(String bankName, UUID cardId, YearMonth billDate)
+            throws BankException {
+        for(int i = 0; i < bankLists.size(); i++) {
+            if(bankLists.get(i).getAccountName().equals(bankName)) {
+                return bankLists.get(i).getCardBillDepositId(cardId, billDate);
+            }
+        }
+        return -1;
     }
 }

--- a/src/main/java/owlmoney/model/bank/Saving.java
+++ b/src/main/java/owlmoney/model/bank/Saving.java
@@ -490,10 +490,7 @@ public class Saving extends Bank {
                 isDepositFound = true;
             }
         }
-        if (isExpenditureFound && isDepositFound) {
-            return true;
-        }
-        return false;
+        return isExpenditureFound && isDepositFound;
     }
 
     /**

--- a/src/main/java/owlmoney/model/bank/Saving.java
+++ b/src/main/java/owlmoney/model/bank/Saving.java
@@ -481,16 +481,16 @@ public class Saving extends Bank {
             UUID transactionCardId = transactions.get(i).getTransactionCardID();
             YearMonth transactionCardBillDate = transactions.get(i).getTransactionCardBillDate();
             boolean isExpenditure = transactions.get(i).getSpent();
-            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+            if (transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
                     && isExpenditure) {
                 isExpenditureFound = true;
             }
-            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+            if (transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
                     && !isExpenditure) {
                 isDepositFound = true;
             }
         }
-        if(isExpenditureFound && isDepositFound) {
+        if (isExpenditureFound && isDepositFound) {
             return true;
         }
         return false;
@@ -510,10 +510,10 @@ public class Saving extends Bank {
             UUID transactionCardId = transactions.get(i).getTransactionCardID();
             YearMonth transactionCardBillDate = transactions.get(i).getTransactionCardBillDate();
             boolean isExpenditure = transactions.get(i).getSpent();
-            if(transactionCardId == null) {
+            if (transactionCardId == null) {
                 continue;
             }
-            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+            if (transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
                     && isExpenditure) {
                 return i;
             }
@@ -535,10 +535,10 @@ public class Saving extends Bank {
             UUID transactionCardId = transactions.get(i).getTransactionCardID();
             YearMonth transactionCardBillDate = transactions.get(i).getTransactionCardBillDate();
             boolean isExpenditure = transactions.get(i).getSpent();
-            if(transactionCardId == null) {
+            if (transactionCardId == null) {
                 continue;
             }
-            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+            if (transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
                     && !isExpenditure) {
                 return i;
             }

--- a/src/main/java/owlmoney/model/bank/Saving.java
+++ b/src/main/java/owlmoney/model/bank/Saving.java
@@ -6,9 +6,11 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.UUID;
 
 import owlmoney.model.bank.exception.BankException;
 import owlmoney.model.transaction.Deposit;
@@ -459,7 +461,88 @@ public class Saving extends Bank {
      * @return Expenditure amount based on the specified expenditure id.
      * @throws TransactionException If transaction is not an expenditure.
      */
+    @Override
     double getExpAmountById(int expenditureId) throws TransactionException {
         return transactions.getExpenditureAmount(expenditureId);
+    }
+
+    /**
+     * Gets if transaction list contains the specified expenditure and deposit.
+     *
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return True if transaction list contains the specified expenditure and deposit.
+     */
+    @Override
+    public boolean isTransactionCardBillExist(UUID cardId, YearMonth billDate) {
+        boolean isExpenditureFound = false;
+        boolean isDepositFound = false;
+        for (int i = 0; i < transactions.getSize(); i++) {
+            UUID transactionCardId = transactions.get(i).getTransactionCardID();
+            YearMonth transactionCardBillDate = transactions.get(i).getTransactionCardBillDate();
+            boolean isExpenditure = transactions.get(i).getSpent();
+            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+                    && isExpenditure) {
+                isExpenditureFound = true;
+            }
+            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+                    && !isExpenditure) {
+                isDepositFound = true;
+            }
+        }
+        if(isExpenditureFound && isDepositFound) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets the index of the expenditure object that is a card bill expenditure
+     * with specified card id and bill date.
+     *
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the expenditure object if found. If not found, return -1.
+     */
+    @Override
+    public int getCardBillExpenditureId(UUID cardId, YearMonth billDate) {
+        for (int i = 0; i < transactions.getSize(); i++) {
+            UUID transactionCardId = transactions.get(i).getTransactionCardID();
+            YearMonth transactionCardBillDate = transactions.get(i).getTransactionCardBillDate();
+            boolean isExpenditure = transactions.get(i).getSpent();
+            if(transactionCardId == null) {
+                continue;
+            }
+            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+                    && isExpenditure) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Gets the index of the deposit object that is a card bill expenditure
+     * with specified card id and bill date.
+     *
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the deposit object if found. If not found, return -1.
+     */
+    @Override
+    public int getCardBillDepositId(UUID cardId, YearMonth billDate) {
+        for (int i = 0; i < transactions.getSize(); i++) {
+            UUID transactionCardId = transactions.get(i).getTransactionCardID();
+            YearMonth transactionCardBillDate = transactions.get(i).getTransactionCardBillDate();
+            boolean isExpenditure = transactions.get(i).getSpent();
+            if(transactionCardId == null) {
+                continue;
+            }
+            if(transactionCardId.equals(cardId) && transactionCardBillDate.equals(billDate)
+                    && !isExpenditure) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/src/main/java/owlmoney/model/card/Card.java
+++ b/src/main/java/owlmoney/model/card/Card.java
@@ -3,6 +3,7 @@ package owlmoney.model.card;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 import owlmoney.model.card.exception.CardException;
 import owlmoney.model.transaction.Transaction;
@@ -19,6 +20,7 @@ public class Card {
     private double rebate;
     private TransactionList paid;
     private TransactionList unpaid;
+    private UUID id;
     private static final int OBJ_DOES_NOT_EXIST = -1;
     private static final int ONE_ARRAY_INDEX = 1;
     private static final int DIVIDE_BY_2 = 2;
@@ -36,6 +38,16 @@ public class Card {
         this.rebate = rebate;
         this.paid = new TransactionList();
         this.unpaid = new TransactionList();
+        this.id = UUID.randomUUID();
+    }
+
+    /**
+     * Gets the card id of the credit card.
+     *
+     * @return id of the credit card.
+     */
+    UUID getId() {
+        return id;
     }
 
     /**

--- a/src/main/java/owlmoney/model/card/CardList.java
+++ b/src/main/java/owlmoney/model/card/CardList.java
@@ -3,6 +3,7 @@ package owlmoney.model.card;
 import java.text.DecimalFormat;
 import java.time.YearMonth;
 import java.util.ArrayList;
+import java.util.UUID;
 
 import owlmoney.model.card.exception.CardException;
 import owlmoney.model.transaction.Transaction;
@@ -426,6 +427,24 @@ public class CardList {
             }
         }
         return rebateAmount;
+    }
+
+    /**
+     * Returns the id of the credit card.
+     *
+     * @param card  The credit card to get the id from.
+     * @return      The id of the credit card.
+     * @throws CardException    If card does not exist.
+     */
+    public UUID getCardId(String card) throws CardException {
+        checkCardExists(card);
+        UUID id = null;
+        for (int i = 0; i < cardLists.size(); i++) {
+            if (card.equals(cardLists.get(i).getName())) {
+                id = cardLists.get(i).getId();
+            }
+        }
+        return id;
     }
 
     /**

--- a/src/main/java/owlmoney/model/profile/Profile.java
+++ b/src/main/java/owlmoney/model/profile/Profile.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 import owlmoney.model.bank.Investment;
 import owlmoney.model.bank.Saving;
@@ -59,6 +60,7 @@ public class Profile {
     private static final String HAS_SPENT = "true";
     private static final String NOT_SPENT = "false";
     private static final String NO_BANK_ACCOUNT = "";
+    private static final int ARRAY_INDEX = 1;
 
     /**
      * Creates a new instance of the user profile.
@@ -1050,6 +1052,32 @@ public class Profile {
     }
 
     /**
+     * Returns the id of the credit card.
+     *
+     * @param card  The credit card to get the id from.
+     * @return      The id of the credit card.
+     * @throws CardException    If card does not exist.
+     */
+    public UUID getCardId(String card) throws CardException {
+        return cardList.getCardId(card);
+    }
+
+    /**
+     * Throws an exception if the credit card bill amount for the specified YearMonth date is zero.
+     *
+     * @param amount    The credit card bill amount.
+     * @param card      The credit card name where is bill is from.
+     * @param cardDate  The credit card YearMonth date of the bill.
+     * @throws CardException    If the credit card bill amount for the specified YearMonth date is zero.
+     */
+    private void checkBillAmountNotZero(double amount, String card, YearMonth cardDate) throws CardException {
+        if (amount == 0) {
+            throw new CardException("You have no paid expenditures for " + card + " for the month of "
+                    + cardDate + "!");
+        }
+    }
+
+    /**
      * Adds the YearMonth's card bill into bank expenditure, card rebates into bank deposit,
      * and transfer card expenditures from unpaid to paid transaction list.
      *
@@ -1063,27 +1091,46 @@ public class Profile {
      * @throws BankException        If bank account does not exist.
      * @throws TransactionException If invalid transaction when transferring transaction.
      */
-    public void payCardBill(String card, String bank, Expenditure expenditure, Deposit deposit, YearMonth cardDate,
-            Ui ui, String type)
-            throws BankException, TransactionException {
-        bankList.bankListAddExpenditure(bank, expenditure, ui, type);
-        ui.printMessage("\n");
-        bankList.bankListAddDeposit(bank, deposit, ui, type);
-        cardList.transferExpUnpaidToPaid(card, cardDate, type);
-        ui.printMessage("Credit Card bill for " + card + " for the month of " + cardDate
-                + " have been successfully paid!");
+    public void addCardBill(String card, String bank, Expenditure expenditure, Deposit deposit, YearMonth cardDate,
+            Ui ui, String type) throws CardException {
+        try {
+            bankList.bankListAddExpenditure(bank, expenditure, ui, type);
+            ui.printMessage("\n");
+            bankList.bankListAddDeposit(bank, deposit, ui, type);
+            cardList.transferExpUnpaidToPaid(card, cardDate, type);
+            ui.printMessage("Credit Card bill for " + card + " for the month of " + cardDate
+                    + " have been successfully paid!");
+        } catch (BankException | TransactionException error) {
+            // Exception should not occur here because this method does not directly receive user inputs.
+            // If exception is thrown, the expenditure list could potentially be corrupted
+            // because some transactions have been transferred and some have not.
+            ui.printMessage(error.getMessage());
+            throw new CardException("Paying of card bill failed! Your data may potentially be corrupted!"
+                    + "Please contact the administrator!");
+        }
+
     }
 
-    /**
-     * Transfers the YearMonth card expenditures from paid to unpaid transaction list.
+    /** Deletes the YearMonth's card bill expenditure and rebates deposit from savings account,
+     * and transfers the YearMonth card expenditures from paid to unpaid transaction list.
      *
      * @param card      The credit card name of the card transactions to be transferred.
      * @param cardDate  The YearMonth date of the card transactions to be transferred.
      * @param ui        The Ui of OwlMoney.
      * @param type      Type of expenditure (card or bank).
      * @throws TransactionException If invalid transaction when transferring transaction.
+     * @throws CardException        If card account does not exist.
+     * @throws BankException        If bank account does not exist.
      */
-    public void unpayCardBill(String card, YearMonth cardDate, Ui ui, String type) throws TransactionException {
+    public void deleteCardBill(String card, YearMonth cardDate, String bank, Ui ui, String type)
+            throws TransactionException, CardException, BankException {
+        checkCardExists(card);
+        checkExpenditureAndDepositExistsInSavings(bank, getCardId(card), cardDate);
+        checkBillAmountNotZero(getCardPaidBillAmount(card, cardDate), card, cardDate);
+        int expenditureNumber = profileGetCardBillExpenditureId(bank,getCardId(card), cardDate) + ARRAY_INDEX;
+        profileDeleteExpenditure(expenditureNumber, bank, ui, type);
+        int depositNumber = profileGetCardBillDepositId(bank,getCardId(card), cardDate) + ARRAY_INDEX;
+        profileDeleteDeposit(depositNumber, bank, ui);
         cardList.transferExpPaidToUnpaid(card, cardDate, type);
         ui.printMessage("Credit Card bill for " + card + " for the month of " + cardDate
                 + " have been successfully reverted!");
@@ -1098,7 +1145,71 @@ public class Profile {
      * @throws BankException        If bank account does not exist.
      * @throws TransactionException If transaction does not exist.
      */
-    public double getBankExpAmountById(String bank, int expenditureId) throws BankException, TransactionException {
+    public double getBankExpAmountById(String bank, int expenditureId)
+            throws BankException, TransactionException {
         return bankList.bankListGetExpAmountById(bank, expenditureId);
+    }
+
+    /**
+     * Gets the index of the transaction object in specific bank that is a card bill expenditure
+     * with specified card id and bill date.
+     *
+     * @param bankName  The name of the bank to search for transaction id.
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the expenditure transaction object if found. If not found, return -1.
+     * @throws BankException If bank account does not support this feature.
+     */
+    public int profileGetCardBillExpenditureId(String bankName, UUID cardId, YearMonth billDate)
+            throws BankException {
+        return bankList.bankListGetCardBillExpenditureId(bankName, cardId, billDate);
+    }
+
+    /**
+     * Gets the index of the transaction object in specific bank that is a card bill deposit
+     * with specified card id and bill date.
+     *
+     * @param bankName  The name of the bank to search for transaction id.
+     * @param cardId    The bill card id to look for in transaction list.
+     * @param billDate  The bill card date to look for in transaction list.
+     * @return Index of the deposit transaction object if found. If not found, return -1.
+     * @throws BankException If bank account does not support this feature.
+     */
+    public int profileGetCardBillDepositId(String bankName, UUID cardId, YearMonth billDate)
+            throws BankException {
+        return bankList.bankListGetCardBillDepositId(bankName, cardId, billDate);
+    }
+
+    /**
+     * Throws CardException if an expenditure and deposit object does not exist in
+     * savings account transaction list.
+     *
+     * @param bankName  The name of the bank to check for existence.
+     * @param cardId    The bill card id to check for existence.
+     * @param billDate  The bill card date to check for existence.
+     * @throws CardException If either expenditure or deposit object not found.
+     * @throws BankException If bank account does not support this feature.
+     */
+    public void checkExpenditureAndDepositExistsInSavings(String bankName, UUID cardId,
+            YearMonth billDate) throws CardException, BankException {
+        int expenditureExist = profileGetCardBillExpenditureId(bankName, cardId, billDate);
+        int depositExist = profileGetCardBillDepositId(bankName, cardId, billDate);
+        boolean isThrowException = false;
+        String accountType = "";
+        if (expenditureExist == -1 && depositExist == -1) {
+            accountType = "bill expenditure and bill rebate deposit";
+            isThrowException = true;
+        } else if (expenditureExist == -1) {
+            accountType = "bill expenditure";
+            isThrowException = true;
+        } else if (depositExist == -1) {
+            accountType = "bill rebate deposit";
+            isThrowException = true;
+        }
+        if (isThrowException) {
+            throw new CardException("Unable to delete credit card bill because " + accountType
+                    + " does not exist in savings account anymore! Could be due to savings account "
+                    + "deleted the transactions because exceeded limit of 2000 transactions.");
+        }
     }
 }

--- a/src/main/java/owlmoney/model/transaction/Deposit.java
+++ b/src/main/java/owlmoney/model/transaction/Deposit.java
@@ -1,6 +1,8 @@
 package owlmoney.model.transaction;
 
+import java.time.YearMonth;
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * Contains the details of a deposit.
@@ -16,6 +18,20 @@ public class Deposit extends Transaction {
      */
     public Deposit(String description, double amount, Date date, String category) {
         super(description, amount, date, category);
+        this.setSpent(false);
+    }
+
+    /**
+     * Creates an instance of an overloaded new Deposit for savings card bill deposit.
+     *
+     * @param description Description of deposit.
+     * @param amount      Amount of deposit.
+     * @param date        Date of deposit.
+     * @param cardId      Id of credit card which the bill belongs to.
+     * @param billDate    Credit card bill date.
+     */
+    public Deposit(String description, double amount, Date date, UUID cardId, YearMonth billDate) {
+        super(description, amount, date, cardId, billDate);
         this.setSpent(false);
     }
 }

--- a/src/main/java/owlmoney/model/transaction/Expenditure.java
+++ b/src/main/java/owlmoney/model/transaction/Expenditure.java
@@ -1,6 +1,8 @@
 package owlmoney.model.transaction;
 
+import java.time.YearMonth;
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * Contains the details of an expenditure.
@@ -16,6 +18,20 @@ public class Expenditure extends Transaction {
      */
     public Expenditure(String description, double amount, Date date, String category) {
         super(description, amount, date, category);
+        this.setSpent(true);
+    }
+
+    /**
+     * Creates an instance of an overloaded new Expenditure for savings card bill expenditure.
+     *
+     * @param description Description of expenditure.
+     * @param amount      Amount of expenditure.
+     * @param date        Date of expenditure.
+     * @param cardId      Id of credit card which the bill belongs to.
+     * @param billDate    Credit card bill date.
+     */
+    public Expenditure(String description, double amount, Date date, UUID cardId, YearMonth billDate) {
+        super(description, amount, date, cardId, billDate);
         this.setSpent(true);
     }
 }

--- a/src/main/java/owlmoney/model/transaction/Transaction.java
+++ b/src/main/java/owlmoney/model/transaction/Transaction.java
@@ -3,8 +3,10 @@ package owlmoney.model.transaction;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.UUID;
 
 /**
  * Contains the details of a transaction.
@@ -16,6 +18,8 @@ public abstract class Transaction {
     private Date date;
     private String category;
     private boolean spent;
+    private UUID cardID;
+    private YearMonth billDate;
 
     /**
      * Creates an instance of a transaction object.
@@ -30,6 +34,24 @@ public abstract class Transaction {
         this.amount = amount;
         this.date = date;
         this.category = category;
+    }
+
+    /**
+     * Creates an overloaded instance of a transaction object for savings card bill transactions.
+     *
+     * @param description The description that describes this expenditure.
+     * @param amount      The amount of money spent in this instance of expenditure.
+     * @param date        The date when this expenditure was made.
+     * @param cardId      The credit card ID.
+     * @param billDate    The YearMonth date of card bill where this transaction is meant for.
+     */
+    public Transaction(String description, double amount, Date date, UUID cardId, YearMonth billDate) {
+        this.description = description;
+        this.amount = amount;
+        this.date = date;
+        this.category = "Credit Card";
+        this.cardID = cardId;
+        this.billDate = billDate;
     }
 
     /**
@@ -153,5 +175,35 @@ public abstract class Transaction {
      */
     void setCategory(String newCategory) {
         this.category = newCategory;
+    }
+
+    /**
+     * Gets the card id that the bill belongs to.
+     *
+     * @return The card id that the bill belongs to.
+     */
+    public UUID getTransactionCardID() {
+        return cardID;
+    }
+
+    /**
+     * Gets the date of the card bill in YearMonth format.
+     *
+     * @return Date of the card bill in YearMonth format.
+     */
+    public YearMonth getTransactionCardBillDate() {
+        return billDate;
+    }
+
+    /**
+     * Gets if this transaction is a card bill.
+     *
+     * @return True if this transaction is a card bill.
+     */
+    public boolean isCardBillTransaction() {
+        if(getTransactionCardID() == null) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/owlmoney/model/transaction/Transaction.java
+++ b/src/main/java/owlmoney/model/transaction/Transaction.java
@@ -201,7 +201,7 @@ public abstract class Transaction {
      * @return True if this transaction is a card bill.
      */
     public boolean isCardBillTransaction() {
-        if(getTransactionCardID() == null) {
+        if (getTransactionCardID() == null) {
             return false;
         }
         return true;

--- a/src/main/java/owlmoney/model/transaction/Transaction.java
+++ b/src/main/java/owlmoney/model/transaction/Transaction.java
@@ -201,9 +201,6 @@ public abstract class Transaction {
      * @return True if this transaction is a card bill.
      */
     public boolean isCardBillTransaction() {
-        if (getTransactionCardID() == null) {
-            return false;
-        }
-        return true;
+        return getTransactionCardID() != null;
     }
 }


### PR DESCRIPTION
Revamp delete credit card bill feature as previous implementation was unintuitive to the user, prone to data corruption, and exploitable by user to increase his money. This new implementation is more intuitive as it no longer requires user to enter savings account expenditure and deposit number as the program will automatically look for the appropriate transactions.