### PR TITLE
Various major and minor bug fixes regarding Credit Card function

### DIFF
--- a/src/main/java/owlmoney/logic/parser/card/ParseCard.java
+++ b/src/main/java/owlmoney/logic/parser/card/ParseCard.java
@@ -82,7 +82,7 @@ public abstract class ParseCard {
      * @throws ParserException If the string is not a double value.
      */
     void checkCashBack(String valueString) throws ParserException {
-        if (!RegexUtil.regexCheckMoney(valueString)) {
+        if (!RegexUtil.regexCheckCashbackRate(valueString)) {
             throw new ParserException("Cash back can only be positive numbers"
                     + " with at most 2 digits and 2 decimal places and at most 20");
         }

--- a/src/main/java/owlmoney/logic/parser/card/ParseEditCard.java
+++ b/src/main/java/owlmoney/logic/parser/card/ParseEditCard.java
@@ -34,7 +34,7 @@ public class ParseEditCard extends ParseCard {
             String key = cardIterator.next();
             String value = cardParameters.get(key);
             if (NAME_PARAMETER.equals(key) && (value.isEmpty() || value.isBlank())) {
-                throw new ParserException("/name cannot be empty.");
+                throw new ParserException(key + " cannot be empty when editing card");
             } else if (NAME_PARAMETER.equals(key)) {
                 checkName(value);
             }

--- a/src/main/java/owlmoney/model/card/Card.java
+++ b/src/main/java/owlmoney/model/card/Card.java
@@ -203,21 +203,6 @@ public class Card {
     }
 
     /**
-     * Lists all the paid expenditures in the current credit card.
-     *
-     * @param ui         Ui of OwlMoney.
-     * @param displayNum Number of expenditure to list.
-     * @throws TransactionException If no expenditure is found or no expenditure is in the list.
-     */
-    void listAllPaidExpenditure(Ui ui, int displayNum) throws TransactionException {
-        try {
-            paid.listExpenditure(ui, displayNum);
-        } catch (TransactionException e) {
-            throw new TransactionException("There are no expenditures in this card.");
-        }
-    }
-
-    /**
      * Deletes an expenditure in the current credit card.
      *
      * @param exId Transaction number of the transaction.
@@ -281,7 +266,7 @@ public class Card {
      * @return True if unpaid expenditure list is empty.
      */
     public boolean isEmpty() {
-        return unpaid.expListIsEmpty();
+        return unpaid.expenditureListIsEmpty();
     }
 
     /**

--- a/src/main/java/owlmoney/model/card/CardList.java
+++ b/src/main/java/owlmoney/model/card/CardList.java
@@ -341,7 +341,7 @@ public class CardList {
      *
      * @param transactionNumber The transaction number.
      * @param editFromCard      The name of the card.
-     * @param desc              The description of the expenditure.
+     * @param description              The description of the expenditure.
      * @param amount            The amount of the expenditure.
      * @param date              The date of the expenditure.
      * @param category          The category of the expenditure.
@@ -349,15 +349,16 @@ public class CardList {
      * @throws CardException        If card does not exist.
      * @throws TransactionException If incorrect date format.
      */
-    public void cardListEditExpenditure(int transactionNumber, String editFromCard, String desc, String amount,
-            String date, String category, Ui ui) throws CardException, TransactionException {
+    public void cardListEditExpenditure(int transactionNumber, String editFromCard, String description,
+            String amount, String date, String category, Ui ui) throws CardException, TransactionException {
         String capitalEditFromCard = editFromCard.toUpperCase();
         for (int i = ISZERO; i < getCardListSize(); i++) {
             Card currentCard = cardLists.get(i);
             String currentCardName = currentCard.getName();
             String capitalCurrentCardName = currentCardName.toUpperCase();
             if (capitalEditFromCard.equals(capitalCurrentCardName)) {
-                cardLists.get(i).editExpenditureDetails(transactionNumber, desc, amount, date, category, ui);
+                cardLists.get(i).editExpenditureDetails(transactionNumber, description, amount, date,
+                        category, ui);
                 try {
                     cardLists.get(i).exportCardPaidTransactionList(Integer.toString(i));
                     cardLists.get(i).exportCardUnpaidTransactionList(Integer.toString(i));

--- a/src/main/java/owlmoney/model/profile/Profile.java
+++ b/src/main/java/owlmoney/model/profile/Profile.java
@@ -1209,22 +1209,19 @@ public class Profile {
      * @param cardDate  The YearMonth date of the card bill.
      * @param ui        The Ui of OwlMoney.
      * @param type      Type of expenditure (card or bank).
-     * @throws BankException        If bank account does not exist.
-     * @throws TransactionException If invalid transaction when transferring transaction.
+     * @throws BankException    If bank account does not exist.
+     * @throws CardException    If invalid transaction when transferring transaction between paid and unpaid.
      */
-    public void addCardBill(String card, String bank, Expenditure expenditure, Deposit deposit, YearMonth cardDate,
-            Ui ui, String type) throws CardException {
+    public void addCardBill(String card, String bank, Expenditure expenditure, Deposit deposit,
+            YearMonth cardDate, Ui ui, String type) throws CardException, BankException {
+        bankList.bankListAddExpenditure(bank, expenditure, ui, type);
+        ui.printMessage("\n");
+        bankList.bankListAddDeposit(bank, deposit, ui, type);
         try {
-            bankList.bankListAddExpenditure(bank, expenditure, ui, type);
-            ui.printMessage("\n");
-            bankList.bankListAddDeposit(bank, deposit, ui, type);
             cardList.transferExpUnpaidToPaid(card, cardDate, type);
             ui.printMessage("Credit Card bill for " + card + " for the month of " + cardDate
                     + " have been successfully paid!");
-        } catch (BankException | TransactionException error) {
-            // Exception should not occur here because this method does not directly receive user inputs.
-            // If exception is thrown, the expenditure list could potentially be corrupted
-            // because some transactions have been transferred and some have not.
+        } catch (TransactionException error) {
             ui.printMessage(error.getMessage());
             throw new CardException("Paying of card bill failed! Your data may potentially be corrupted!");
         }

--- a/src/main/java/owlmoney/model/profile/Profile.java
+++ b/src/main/java/owlmoney/model/profile/Profile.java
@@ -215,18 +215,23 @@ public class Profile {
     /**
      * Adds a new expenditure tied to a specific bank account or credit card.
      *
-     * @param bankName The name of the bank account or credit card.
+     * @param accountName The name of the bank account or credit card.
      * @param expenditure     An expenditure object.
      * @param ui      required for printing.
      * @param type    Represents type of expenditure to be added.
      * @throws BankException If bank amount becomes negative after adding expenditure.
+     * @throws CardException If card bill for the expenditure's month has already been paid.
      */
-    public void profileAddNewExpenditure(String bankName, Transaction expenditure, Ui ui, String type)
+    public void profileAddNewExpenditure(String accountName, Transaction expenditure, Ui ui, String type)
             throws BankException, CardException {
         if (CARD.equals(type)) {
-            cardList.cardListAddExpenditure(bankName, expenditure, ui, type);
+            if (getCardPaidBillAmount(accountName, expenditure.getYearMonthDate()) != 0) {
+                throw new CardException("You cannot add an expenditure with month that the card bill "
+                + "has already been paid for!");
+            }
+            cardList.cardListAddExpenditure(accountName, expenditure, ui, type);
         } else if (BANK.equals(type) || BONDS.equals(type)) {
-            bankList.bankListAddExpenditure(bankName, expenditure, ui, type);
+            bankList.bankListAddExpenditure(accountName, expenditure, ui, type);
         }
     }
 
@@ -1223,7 +1228,6 @@ public class Profile {
             ui.printMessage(error.getMessage());
             throw new CardException("Paying of card bill failed! Your data may potentially be corrupted!");
         }
-
     }
 
     /** Deletes the YearMonth's card bill expenditure and rebates deposit from savings account,

--- a/src/main/java/owlmoney/model/transaction/Transaction.java
+++ b/src/main/java/owlmoney/model/transaction/Transaction.java
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.UUID;
 
@@ -117,6 +118,17 @@ public abstract class Transaction {
     public LocalDate getLocalDate() {
         LocalDate localDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
         return localDate;
+    }
+
+    /**
+     * Gets the date that this expenditure was made in YearMonth format.
+     *
+     * @return The date that the expenditure was made in YearMonth format.
+     */
+    public YearMonth getYearMonthDate() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMMM yyyy");
+        YearMonth date = YearMonth.parse(this.getDate(), formatter);
+        return date;
     }
 
     /**

--- a/src/main/java/owlmoney/model/transaction/TransactionList.java
+++ b/src/main/java/owlmoney/model/transaction/TransactionList.java
@@ -379,9 +379,9 @@ public class TransactionList {
         double totalAmount = 0;
         for (int i = 0; i < transactionLists.size(); i++) {
             LocalDate date = transactionLists.get(i).getLocalDate();
-            int expMonth = date.getMonthValue();
-            int expYear = date.getYear();
-            if (expMonth == month && expYear == year) {
+            int expenditureMonth = date.getMonthValue();
+            int expenditureYear = date.getYear();
+            if (expenditureMonth == month && expenditureYear == year) {
                 totalAmount += transactionLists.get(i).getAmount();
             }
         }
@@ -391,21 +391,21 @@ public class TransactionList {
     /**
      * Returns the particular transaction month based on transaction number.
      *
-     * @param expNum Transaction number to get the month of.
+     * @param expenditureNumber Transaction number to get the month of.
      * @return Transaction month.
      */
-    public int getTransactionMonthByIndex(int expNum) {
-        return transactionLists.get(expNum - 1).getLocalDate().getMonthValue();
+    public int getTransactionMonthByIndex(int expenditureNumber) {
+        return transactionLists.get(expenditureNumber - 1).getLocalDate().getMonthValue();
     }
 
     /**
      * Returns the particular transaction year based on transaction number.
      *
-     * @param expNum Transaction number to get the year of.
+     * @param expenditureNumber Transaction number to get the year of.
      * @return Transaction year.
      */
-    public int getTransactionYearByIndex(int expNum) {
-        return transactionLists.get(expNum - 1).getLocalDate().getYear();
+    public int getTransactionYearByIndex(int expenditureNumber) {
+        return transactionLists.get(expenditureNumber - 1).getLocalDate().getYear();
     }
 
     /**
@@ -413,7 +413,7 @@ public class TransactionList {
      *
      * @return True if expenditure list is empty.
      */
-    public boolean expListIsEmpty() {
+    public boolean expenditureListIsEmpty() {
         return transactionLists.isEmpty();
     }
 
@@ -429,7 +429,7 @@ public class TransactionList {
      */
     public void findMatchingTransaction(String fromDate, String toDate,
             String description, String category, Ui ui) throws TransactionException {
-        if (expListIsEmpty()) {
+        if (expenditureListIsEmpty()) {
             ui.printMessage("Transaction list is empty.");
             return;
         }


### PR DESCRIPTION
Resolves #194
Resolves #195
Resolves #209
Resolves #211

Fixes bug #194 to prevent user from paying card bill for a particular month if it has already been paid before.
Fixes bug #195 to prevent user from adding card expenditure for a particular month if card bill for that particular month has been paid before.
Fixes bug #209 calling incorrect regex which could cause card rebate to exceed 20%.
Fixes bug #209 inconsistent error messages.